### PR TITLE
Restricted flows to only pick logs from simulation pods

### DIFF
--- a/controllers/provision.go
+++ b/controllers/provision.go
@@ -70,7 +70,7 @@ func (r *FlowTestReconciler) provisionResource(ctx context.Context) error {
 				// TODO: Handle more than or less than 1 Container (#12)
 				Name:            referencePod.Spec.Containers[0].Name,
 				ImagePullPolicy: v1.PullIfNotPresent,
-				Image:           "mrsupiri/pod-simulator:latest",
+				Image:           "supiri/pod-simulator:latest",
 				Args:            []string{"-log_file", "/simulation.log"},
 				VolumeMounts:    []v1.VolumeMount{{Name: "config-volume", MountPath: "/simulation.log", SubPath: "simulation.log"}},
 			}},
@@ -187,7 +187,7 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 
 			targetFlow.Spec.Match = nil
 
-			targetFlow.Spec.Filters = referenceFlow.Spec.Filters[:x]
+			targetFlow.Spec.Filters = append(targetFlow.Spec.Filters, referenceFlow.Spec.Filters[:x]...)
 
 			if err = r.Create(ctx, &targetOutput); err != nil {
 				logger.Error(err, fmt.Sprintf("failed to deploy Flow #%d for %s", i, referenceFlow.ObjectMeta.Name))
@@ -265,7 +265,7 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 
 			targetFlow.Spec.Match = nil
 
-			targetFlow.Spec.Filters = referenceFlow.Spec.Filters[:x]
+			targetFlow.Spec.Filters = append(targetFlow.Spec.Filters, referenceFlow.Spec.Filters[:x]...)
 
 			if err = r.Create(ctx, &targetOutput); err != nil {
 				logger.Error(err, fmt.Sprintf("failed to deploy Flow #%d for %s", i, referenceFlow.ObjectMeta.Name))

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	flowv1beta1 "github.com/banzaicloud/logging-operator/pkg/sdk/api/v1beta1"
+	filters "github.com/banzaicloud/logging-operator/pkg/sdk/model/filter"
 	"github.com/banzaicloud/logging-operator/pkg/sdk/model/output"
 	loggingplumberv1alpha1 "github.com/mrsupiri/logging-pipeline-plumber/pkg/sdk/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,14 @@ func flowTemplates(flow flowv1beta1.Flow, flowTest loggingplumberv1alpha1.FlowTe
 			LocalOutputRefs: nil,
 			Match: []flowv1beta1.Match{{
 				Select: &flowv1beta1.Select{Labels: extraLabels},
+			}},
+			Filters: []flowv1beta1.Filter{{
+				Grep: &filters.GrepConfig{
+					Regexp: []filters.RegexpSection{{
+						Key:     "kubernetes",
+						Pattern: ".*loggingplumber.isala.me\\/flowtest-uuid.*",
+					}},
+				},
 			}},
 		},
 	}
@@ -73,6 +82,16 @@ func clusterFlowTemplates(flow flowv1beta1.ClusterFlow, flowTest loggingplumberv
 			GlobalOutputRefs: nil,
 			Match: []flowv1beta1.ClusterMatch{{
 				ClusterSelect: &flowv1beta1.ClusterSelect{Labels: extraLabels},
+			}},
+			Filters: []flowv1beta1.Filter{{
+				Grep: &filters.GrepConfig{
+					Regexp: []filters.RegexpSection{{
+						// Make sure "loggingplumber.isala.me/flowtest-uuid" label is present
+						// To prevent data filter out logs from reference pod
+						Key:     "kubernetes",
+						Pattern: ".*loggingplumber.isala.me\\/flowtest-uuid.*",
+					}},
+				},
 			}},
 		},
 	}


### PR DESCRIPTION
I have added a special filter to every simulation flow the operator deploys which will look for `loggingplumber.isala.me/flowtest-uuid` label and if it's not present the log won't be passed to the output. This label is added only by our operator when deploying simulation pods

ex output -
```
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:06Z] @DEBUG Tam ipsae consuetudo infelix adtendi contexo mansuefecisti diutius re. 1373 ::0.403911","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:07Z] @WARNING Ne hi flagitantur alienam neglecta. 1374 ::0.474177","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:08Z] @INFO Amo ideoque die se at, caro aer, ad cor. 1375 ::0.263548","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:09Z] @INFO Se contexo servis inpiis erogo, diligit ita significaret eosdem. 1376 ::0.405282","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:06Z] @DEBUG Tam ipsae consuetudo infelix adtendi contexo mansuefecisti diutius re. 1373 ::0.403911","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:07Z] @WARNING Ne hi flagitantur alienam neglecta. 1374 ::0.474177","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:08Z] @INFO Amo ideoque die se at, caro aer, ad cor. 1375 ::0.263548","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:09Z] @INFO Se contexo servis inpiis erogo, diligit ita significaret eosdem. 1376 ::0.405282","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:06Z] @DEBUG Tam ipsae consuetudo infelix adtendi contexo mansuefecisti diutius re. 1373 ::0.403911","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:07Z] @WARNING Ne hi flagitantur alienam neglecta. 1374 ::0.474177","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:08Z] @INFO Amo ideoque die se at, caro aer, ad cor. 1375 ::0.263548","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:09Z] @INFO Se contexo servis inpiis erogo, diligit ita significaret eosdem. 1376 ::0.405282","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:06Z] @DEBUG Tam ipsae consuetudo infelix adtendi contexo mansuefecisti diutius re. 1373 ::0.403911","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
{"stream":"stdout","logtag":"F","message":"[2021-06-10T11:50:07Z] @WARNING Ne hi flagitantur alienam neglecta. 1374 ::0.474177","kubernetes":{"pod_name":"4a7629e7-13b1-4dea-9931-94c5ed28dee1-simulation","namespace_name":"default","pod_id":"712b4ae0-def3-429a-83a2-86fdefb17ab6","labels":{"app.kubernetes.io/created-by":"logging-plumber","app.kubernetes.io/managed-by":"logging-pipeline-plumber","app.kubernetes.io/name":"pod-simulation","loggingplumber.isala.me/flowtest":"flowtest-sample","loggingplumber.isala.me/flowtest-uuid":"4a7629e7-13b1-4dea-9931-94c5ed28dee1","loggingplumber.isala.me/test":"simulations"},"host":"k3d-rancher-logging-explorer-server-0","container_name":"busybox","docker_id":"fe90bded20f3b2e898456932d0fcb182656bc788aa9a8d1869e86a8d78ed6f70","container_hash":"sha256:342ce0c89ef13c2dba905e6328ef0e17017d3cf6cb765df220075e6cc1033f18","container_image":"docker.io/supiri/pod-simulator:dev"},"foo":"bar"}
```

Issue: #42 