### PR TITLE
Made PodSimulator and LogOutput images changeable

### DIFF
--- a/charts/logging-pipeline-plumber/templates/NOTES.txt
+++ b/charts/logging-pipeline-plumber/templates/NOTES.txt
@@ -1,22 +1,3 @@
-1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "logging-pipeline-plumber.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "logging-pipeline-plumber.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "logging-pipeline-plumber.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "logging-pipeline-plumber.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:9090 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 9090:$CONTAINER_PORT
-{{- end }}
+1. To access the rancher logging pipeline plumber UI RUN:
+  echo "Visit http://127.0.0.1:9090 to get to dashboard"
+  kubectl port-forward svc/logging-pipeline-plumber 9090:9090

--- a/charts/logging-pipeline-plumber/templates/deployment.yaml
+++ b/charts/logging-pipeline-plumber/templates/deployment.yaml
@@ -33,6 +33,14 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args: [
+            "-pod-simulator-repository={{ .Values.podSimulator.repository }}",
+            "-pod-simulator-tag={{ .Values.podSimulator.tag }}",
+            "-pod-simulator-pull-policy={{ .Values.podSimulator.pullPolicy }}",
+            "-log-output-repository={{ .Values.logOutput.repository }}",
+            "-log-output-tag={{ .Values.logOutput.tag }}",
+            "-log-output-pull-policy={{ .Values.logOutput.pullPolicy }}",
+          ]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/logging-pipeline-plumber/templates/deployment.yaml
+++ b/charts/logging-pipeline-plumber/templates/deployment.yaml
@@ -34,12 +34,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args: [
-            "-pod-simulator-repository={{ .Values.podSimulator.repository }}",
-            "-pod-simulator-tag={{ .Values.podSimulator.tag }}",
-            "-pod-simulator-pull-policy={{ .Values.podSimulator.pullPolicy }}",
-            "-log-output-repository={{ .Values.logOutput.repository }}",
-            "-log-output-tag={{ .Values.logOutput.tag }}",
-            "-log-output-pull-policy={{ .Values.logOutput.pullPolicy }}",
+            "-pod-simulator-image-repository={{ .Values.podSimulatorImage.repository }}",
+            "-pod-simulator-image-tag={{ .Values.podSimulatorImage.tag }}",
+            "-pod-simulator-image-pull-policy={{ .Values.podSimulatorImage.pullPolicy }}",
+            "-log-output-image-repository={{ .Values.logOutputImage.repository }}",
+            "-log-output-image-tag={{ .Values.logOutputImage.tag }}",
+            "-log-output-image-pull-policy={{ .Values.logOutputImage.pullPolicy }}",
           ]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/logging-pipeline-plumber/values.yaml
+++ b/charts/logging-pipeline-plumber/values.yaml
@@ -10,12 +10,12 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
-logOutput:
+logOutputImage:
   repository: paynejacob/log-output
   pullPolicy: IfNotPresent
   tag: "latest"
 
-podSimulator:
+podSimulatorImage:
   repository: supiri/pod-simulator
   pullPolicy: IfNotPresent
   tag: "latest"

--- a/charts/logging-pipeline-plumber/values.yaml
+++ b/charts/logging-pipeline-plumber/values.yaml
@@ -10,6 +10,16 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
+logOutput:
+  repository: paynejacob/log-output
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+podSimulator:
+  repository: supiri/pod-simulator
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/controllers/flowtest_controller.go
+++ b/controllers/flowtest_controller.go
@@ -34,6 +34,8 @@ import (
 
 // FlowTestReconciler reconciles a FlowTest object
 type FlowTestReconciler struct {
+	PodSimulatorImage Image
+	LogOutputImage    Image
 	client.Client
 	Scheme *runtime.Scheme
 }

--- a/controllers/provision.go
+++ b/controllers/provision.go
@@ -69,8 +69,8 @@ func (r *FlowTestReconciler) provisionResource(ctx context.Context) error {
 			Containers: []v1.Container{{
 				// TODO: Handle more than or less than 1 Container (#12)
 				Name:            referencePod.Spec.Containers[0].Name,
-				ImagePullPolicy: v1.PullIfNotPresent,
-				Image:           "supiri/pod-simulator:latest",
+				Image:           fmt.Sprintf("%s:%s", r.PodSimulatorImage.Repository, r.PodSimulatorImage.Tag),
+				ImagePullPolicy: v1.PullPolicy(r.PodSimulatorImage.PullPolicy),
 				Args:            []string{"-log_file", "/simulation.log"},
 				VolumeMounts:    []v1.VolumeMount{{Name: "config-volume", MountPath: "/simulation.log", SubPath: "simulation.log"}},
 			}},
@@ -305,8 +305,8 @@ func (r *FlowTestReconciler) provisionOutputResource(ctx context.Context) error 
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
 						Name:            "log-output",
-						Image:           "paynejacob/log-output:latest",
-						ImagePullPolicy: v1.PullIfNotPresent,
+						Image:           fmt.Sprintf("%s:%s", r.LogOutputImage.Repository, r.LogOutputImage.Tag),
+						ImagePullPolicy: v1.PullPolicy(r.LogOutputImage.PullPolicy),
 						Ports: []v1.ContainerPort{{
 							Name:          "http",
 							ContainerPort: 80,

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -144,6 +144,12 @@ type Index struct {
 	LogCount int       `json:"log_count"`
 }
 
+type Image struct {
+	Repository string
+	Tag        string
+	PullPolicy string
+}
+
 // https://stackoverflow.com/a/40326580
 func getEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {

--- a/main.go
+++ b/main.go
@@ -58,10 +58,21 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var webAddr string
+	var podSimulator controllers.Image
+	var logOutput controllers.Image
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&webAddr, "web-addr", ":9090", "The address the frontend API endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+
+	flag.StringVar(&podSimulator.Repository, "pod-simulator-repository", "supiri/pod-simulator", "container image URI for pod simulator")
+	flag.StringVar(&podSimulator.Tag, "pod-simulator-tag", "latest", "pod simulator container tag")
+	flag.StringVar(&podSimulator.PullPolicy, "pod-simulator-pull-policy", "IfNotPresent", "pull policy pod simulator container")
+
+	flag.StringVar(&logOutput.Repository, "log-output-repository", "paynejacob/log-output", "container image URI for log-output")
+	flag.StringVar(&logOutput.Tag, "log-output-tag", "latest", "log-output container tag")
+	flag.StringVar(&logOutput.PullPolicy, "log-output-pull-policy", "IfNotPresent", "pull policy log-output container")
+
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -87,8 +98,10 @@ func main() {
 	}
 
 	if err = (&controllers.FlowTestReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		PodSimulatorImage: podSimulator,
+		LogOutputImage:    logOutput,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "FlowTest")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -58,20 +58,20 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var webAddr string
-	var podSimulator controllers.Image
-	var logOutput controllers.Image
+	var podSimulatorImage controllers.Image
+	var logOutputImage controllers.Image
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&webAddr, "web-addr", ":9090", "The address the frontend API endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 
-	flag.StringVar(&podSimulator.Repository, "pod-simulator-repository", "supiri/pod-simulator", "container image URI for pod simulator")
-	flag.StringVar(&podSimulator.Tag, "pod-simulator-tag", "latest", "pod simulator container tag")
-	flag.StringVar(&podSimulator.PullPolicy, "pod-simulator-pull-policy", "IfNotPresent", "pull policy pod simulator container")
+	flag.StringVar(&podSimulatorImage.Repository, "pod-simulator-image-repository", "supiri/pod-simulator", "container image URI for pod simulator")
+	flag.StringVar(&podSimulatorImage.Tag, "pod-simulator-image-tag", "latest", "pod simulator container tag")
+	flag.StringVar(&podSimulatorImage.PullPolicy, "pod-simulator-image-pull-policy", "IfNotPresent", "pull policy pod simulator container")
 
-	flag.StringVar(&logOutput.Repository, "log-output-repository", "paynejacob/log-output", "container image URI for log-output")
-	flag.StringVar(&logOutput.Tag, "log-output-tag", "latest", "log-output container tag")
-	flag.StringVar(&logOutput.PullPolicy, "log-output-pull-policy", "IfNotPresent", "pull policy log-output container")
+	flag.StringVar(&logOutputImage.Repository, "log-output-image-repository", "paynejacob/log-output", "container image URI for log-output")
+	flag.StringVar(&logOutputImage.Tag, "log-output-image-tag", "latest", "log-output container tag")
+	flag.StringVar(&logOutputImage.PullPolicy, "log-output-image-pull-policy", "IfNotPresent", "pull policy log-output container")
 
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -98,8 +98,8 @@ func main() {
 	}
 
 	if err = (&controllers.FlowTestReconciler{
-		PodSimulatorImage: podSimulator,
-		LogOutputImage:    logOutput,
+		PodSimulatorImage: podSimulatorImage,
+		LogOutputImage:    logOutputImage,
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
I created 6 ENV variables which are controlled by helm values, so now users can uses the `helm install` command to change the image repository, pullPolicy, and tag

Ex -
```sh
helm install logging-pipeline-plumber --set image.tag=dev --set podSimulator.tag=dev charts/logging-pipeline-plumber
```

Issue - #40 
