### PR TITLE
Changed the peeling mechanism

### DIFF
--- a/charts/logging-pipeline-plumber/Chart.yaml
+++ b/charts/logging-pipeline-plumber/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0-a4
+version: 100.100.100-dev
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.0-a4"
+appVersion: "v100.100.100-dev"

--- a/charts/logging-pipeline-plumber/Chart.yaml
+++ b/charts/logging-pipeline-plumber/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 100.100.100-dev
+version: 0.1.0-a4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v100.100.100-dev"
+appVersion: "v0.1.0-a4"

--- a/config/samples/simulations.yaml
+++ b/config/samples/simulations.yaml
@@ -15,13 +15,13 @@ spec:
         labels:
           loggingplumber.isala.me/test: simulations
   filters:
-    - record_modifier:
-        records:
-          - foo: "bar"
     - grep:
         regexp:
           - key: first
             pattern: /^5\d\d$/
+    - record_modifier:
+        records:
+          - foo: "bar"
 ---
 apiVersion: logging.banzaicloud.io/v1beta1
 kind: Output

--- a/controllers/cleanup.go
+++ b/controllers/cleanup.go
@@ -111,9 +111,9 @@ func (r *FlowTestReconciler) cleanUpOutputResources(ctx context.Context) error {
 		logger.Error(err, fmt.Sprintf("failed to get provisioned %s", flowTests.Kind))
 		return err
 	}
-	if len(flowTests.Items) > 1{
+	if len(flowTests.Items) > 1 {
 		for _, flowTest := range flowTests.Items {
-			if flowTest.Status.Status != loggingplumberv1alpha1.Completed || flowTest.ObjectMeta.DeletionTimestamp.IsZero() {
+			if flowTest.Status.Status != loggingplumberv1alpha1.Completed && !flowTest.ObjectMeta.DeletionTimestamp.IsZero() {
 				logger.V(1).Info("unfinished flowtest found, skipping cleanup of log-aggregator")
 				return nil
 			}

--- a/controllers/cleanup.go
+++ b/controllers/cleanup.go
@@ -107,16 +107,20 @@ func (r *FlowTestReconciler) cleanUpOutputResources(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 
 	var flowTests loggingplumberv1alpha1.FlowTestList
-	if err := r.List(ctx, &flowTests, &client.MatchingLabels{"app.kubernetes.io/created-by": "logging-plumber"}); err != nil {
+	if err := r.List(ctx, &flowTests); err != nil {
 		logger.Error(err, fmt.Sprintf("failed to get provisioned %s", flowTests.Kind))
 		return err
 	}
-	for _, flowTest := range flowTests.Items {
-		if flowTest.Status.Status != loggingplumberv1alpha1.Completed {
-			logger.V(1).Info("unfinished flowtest found, skipping cleanUpOutputResources")
-			return nil
+	if len(flowTests.Items) > 1{
+		for _, flowTest := range flowTests.Items {
+			if flowTest.Status.Status != loggingplumberv1alpha1.Completed || flowTest.ObjectMeta.DeletionTimestamp.IsZero() {
+				logger.V(1).Info("unfinished flowtest found, skipping cleanup of log-aggregator")
+				return nil
+			}
 		}
 	}
+
+	logger.V(1).Info("no running flowtest found, cleaning up log-aggregator")
 
 	matchingLabels := &client.MatchingLabels{"loggingplumber.isala.me/component": "log-aggregator"}
 	var podList v1.PodList
@@ -152,6 +156,8 @@ func (r *FlowTestReconciler) cleanUpOutputResources(ctx context.Context) error {
 
 func (r *FlowTestReconciler) deleteResources(ctx context.Context, finalizerName string) error {
 	flowTest := ctx.Value("flowTest").(loggingplumberv1alpha1.FlowTest)
+	logger := log.FromContext(ctx)
+
 	if err := r.cleanUpResources(ctx, flowTest.ObjectMeta.Name); client.IgnoreNotFound(err) != nil {
 		return err
 	}
@@ -161,6 +167,7 @@ func (r *FlowTestReconciler) deleteResources(ctx context.Context, finalizerName 
 	// remove our finalizer from the list and update it.
 	controllerutil.RemoveFinalizer(&flowTest, finalizerName)
 	if err := r.Update(ctx, &flowTest); err != nil {
+		logger.Error(err, "failed to remove the finalizer")
 		return err
 	}
 	return nil

--- a/controllers/flowtest_controller.go
+++ b/controllers/flowtest_controller.go
@@ -68,9 +68,9 @@ func (r *FlowTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	logger.Info("Reconciling")
 
 	var flowTest loggingplumberv1alpha1.FlowTest
-	if err := r.Get(ctx, req.NamespacedName, &flowTest); err != nil  {
+	if err := r.Get(ctx, req.NamespacedName, &flowTest); err != nil {
 		// all the resources are already deleted
-		if apierrors.IsNotFound(err){
+		if apierrors.IsNotFound(err) {
 			// Remove if log aggregator is still running
 			if err := r.cleanUpOutputResources(ctx); client.IgnoreNotFound(err) != nil {
 				return ctrl.Result{Requeue: true}, err
@@ -96,7 +96,7 @@ func (r *FlowTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{Requeue: false}, nil
 	}
 
-	if flowTest.ObjectMeta.Name == ""{
+	if flowTest.ObjectMeta.Name == "" {
 		logger.V(-1).Info("flowtest without a name queued")
 		return ctrl.Result{Requeue: false}, nil
 	}

--- a/controllers/flowtest_controller.go
+++ b/controllers/flowtest_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -67,7 +68,15 @@ func (r *FlowTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	logger.Info("Reconciling")
 
 	var flowTest loggingplumberv1alpha1.FlowTest
-	if err := r.Get(ctx, req.NamespacedName, &flowTest); err != client.IgnoreNotFound(err) {
+	if err := r.Get(ctx, req.NamespacedName, &flowTest); err != nil  {
+		// all the resources are already deleted
+		if apierrors.IsNotFound(err){
+			// Remove if log aggregator is still running
+			if err := r.cleanUpOutputResources(ctx); client.IgnoreNotFound(err) != nil {
+				return ctrl.Result{Requeue: true}, err
+			}
+			return ctrl.Result{Requeue: false}, nil
+		}
 		logger.Error(err, "failed to get the flowtest")
 		return ctrl.Result{Requeue: false}, err
 	}
@@ -84,7 +93,12 @@ func (r *FlowTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{Requeue: true}, err
 		}
 		// Stop reconciliation as the item is being deleted
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: false}, nil
+	}
+
+	if flowTest.ObjectMeta.Name == ""{
+		logger.V(-1).Info("flowtest without a name queued")
+		return ctrl.Result{Requeue: false}, nil
 	}
 
 	// Reconcile depending on status
@@ -95,15 +109,16 @@ func (r *FlowTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// Set the finalizer
 		controllerutil.AddFinalizer(&flowTest, finalizerName)
 		if err := r.Update(ctx, &flowTest); err != nil {
-			logger.Error(err, "failed to update flowtest status")
+			logger.Error(err, "failed to add finalizer")
 			return ctrl.Result{Requeue: true}, err
 		}
 		// Set the status
 		flowTest.Status.Status = loggingplumberv1alpha1.Created
 		if err := r.Status().Update(ctx, &flowTest); err != nil {
-			logger.Error(err, "failed to update flowtest status")
+			logger.Error(err, "failed to set status as created")
 			return ctrl.Result{Requeue: true}, err
 		}
+		r.Recorder.Event(&flowTest, v1.EventTypeNormal, EventReasonProvision, "moved to created state")
 		return ctrl.Result{Requeue: true}, nil
 
 	case loggingplumberv1alpha1.Created:
@@ -121,7 +136,7 @@ func (r *FlowTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if time.Now().After(fiveMinuteAfterCreation) {
 			flowTest.Status.Status = loggingplumberv1alpha1.Completed
 			if err := r.Status().Update(ctx, &flowTest); err != nil {
-				logger.Error(err, "failed to update flowtest status")
+				logger.Error(err, "failed to set status as completed")
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil

--- a/controllers/provision.go
+++ b/controllers/provision.go
@@ -143,7 +143,7 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 
 		i := 0
 		flowTemplate, outTemplate := r.clusterFlowTemplates(referenceFlow, *flowTest, extraLabels)
-		for x := 1; x <= len(referenceFlow.Spec.Match); x++ {
+		for x := 0; x <= len(referenceFlow.Spec.Match)-1; x++ {
 			targetFlow := *flowTemplate.DeepCopy()
 			targetOutput := *outTemplate.DeepCopy()
 
@@ -158,7 +158,7 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 
 			targetFlow.Spec.GlobalOutputRefs = []string{targetOutput.ObjectMeta.Name}
 
-			targetFlow.Spec.Match = append(targetFlow.Spec.Match, referenceFlow.Spec.Match[:x]...)
+			targetFlow.Spec.Match = append(targetFlow.Spec.Match, referenceFlow.Spec.Match[x])
 
 			if err = r.Create(ctx, &targetOutput); err != nil {
 				logger.Error(err, fmt.Sprintf("failed to deploy Flow #%d for %s", i, referenceFlow.ObjectMeta.Name))
@@ -221,7 +221,7 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 		i := 0
 		flowTemplate, outTemplate := r.flowTemplates(referenceFlow, *flowTest, extraLabels)
 
-		for x := 1; x <= len(referenceFlow.Spec.Match); x++ {
+		for x := 0; x <= len(referenceFlow.Spec.Match)-1; x++ {
 			targetFlow := *flowTemplate.DeepCopy()
 			targetOutput := *outTemplate.DeepCopy()
 
@@ -236,7 +236,7 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 
 			targetFlow.Spec.LocalOutputRefs = []string{targetOutput.ObjectMeta.Name}
 
-			targetFlow.Spec.Match = append(targetFlow.Spec.Match, referenceFlow.Spec.Match[:x]...)
+			targetFlow.Spec.Match = append(targetFlow.Spec.Match, referenceFlow.Spec.Match[x])
 
 			if err = r.Create(ctx, &targetOutput); err != nil {
 				logger.Error(err, fmt.Sprintf("failed to deploy Flow #%d for %s", i, referenceFlow.ObjectMeta.Name))

--- a/controllers/provision.go
+++ b/controllers/provision.go
@@ -142,7 +142,7 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 		flowTest.Status.FilterStatus = make([]bool, len(referenceFlow.Spec.Filters))
 
 		i := 0
-		flowTemplate, outTemplate := r.clusterFlowTemplates(referenceFlow, *flowTest, extraLabels)
+		flowTemplate, outTemplate := r.clusterFlowTemplates(referenceFlow, *flowTest)
 		for x := 0; x <= len(referenceFlow.Spec.Match)-1; x++ {
 			targetFlow := *flowTemplate.DeepCopy()
 			targetOutput := *outTemplate.DeepCopy()
@@ -158,7 +158,7 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 
 			targetFlow.Spec.GlobalOutputRefs = []string{targetOutput.ObjectMeta.Name}
 
-			targetFlow.Spec.Match = append(targetFlow.Spec.Match, referenceFlow.Spec.Match[x])
+			targetFlow.Spec.Match = []flowv1beta1.ClusterMatch{referenceFlow.Spec.Match[x]}
 
 			if err = r.Create(ctx, &targetOutput); err != nil {
 				logger.Error(err, fmt.Sprintf("failed to deploy Flow #%d for %s", i, referenceFlow.ObjectMeta.Name))
@@ -189,7 +189,10 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 
 			targetFlow.Spec.GlobalOutputRefs = []string{targetOutput.ObjectMeta.Name}
 
-			targetFlow.Spec.Match = nil
+			// ensure logs are only coming from our simulation pod
+			targetFlow.Spec.Match = []flowv1beta1.ClusterMatch{{
+				ClusterSelect: &flowv1beta1.ClusterSelect{Labels: extraLabels},
+			}}
 
 			targetFlow.Spec.Filters = append(targetFlow.Spec.Filters, referenceFlow.Spec.Filters[:x]...)
 
@@ -219,7 +222,7 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 		flowTest.Status.FilterStatus = make([]bool, len(referenceFlow.Spec.Filters))
 
 		i := 0
-		flowTemplate, outTemplate := r.flowTemplates(referenceFlow, *flowTest, extraLabels)
+		flowTemplate, outTemplate := r.flowTemplates(referenceFlow, *flowTest)
 
 		for x := 0; x <= len(referenceFlow.Spec.Match)-1; x++ {
 			targetFlow := *flowTemplate.DeepCopy()
@@ -236,7 +239,7 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 
 			targetFlow.Spec.LocalOutputRefs = []string{targetOutput.ObjectMeta.Name}
 
-			targetFlow.Spec.Match = append(targetFlow.Spec.Match, referenceFlow.Spec.Match[x])
+			targetFlow.Spec.Match = []flowv1beta1.Match{referenceFlow.Spec.Match[x]}
 
 			if err = r.Create(ctx, &targetOutput); err != nil {
 				logger.Error(err, fmt.Sprintf("failed to deploy Flow #%d for %s", i, referenceFlow.ObjectMeta.Name))
@@ -267,7 +270,10 @@ func (r *FlowTestReconciler) deploySlicedFlows(ctx context.Context, extraLabels 
 
 			targetFlow.Spec.LocalOutputRefs = []string{targetOutput.ObjectMeta.Name}
 
-			targetFlow.Spec.Match = nil
+			// ensure logs are only coming from our simulation pod
+			targetFlow.Spec.Match = []flowv1beta1.Match{{
+				Select: &flowv1beta1.Select{Labels: extraLabels},
+			}}
 
 			targetFlow.Spec.Filters = append(targetFlow.Spec.Filters, referenceFlow.Spec.Filters[:x]...)
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -22,7 +22,7 @@ const (
 	EventReasonReconcile        = "Reconcile"
 )
 
-func (r *FlowTestReconciler) flowTemplates(flow flowv1beta1.Flow, flowTest loggingplumberv1alpha1.FlowTest, extraLabels map[string]string) (flowv1beta1.Flow, flowv1beta1.Output) {
+func (r *FlowTestReconciler) flowTemplates(flow flowv1beta1.Flow, flowTest loggingplumberv1alpha1.FlowTest) (flowv1beta1.Flow, flowv1beta1.Output) {
 	flowTemplate := flowv1beta1.Flow{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "logging.banzaicloud.io/v1beta1",
@@ -35,9 +35,7 @@ func (r *FlowTestReconciler) flowTemplates(flow flowv1beta1.Flow, flowTest loggi
 		},
 		Spec: flowv1beta1.FlowSpec{
 			LocalOutputRefs: nil,
-			Match: []flowv1beta1.Match{{
-				//Select: &flowv1beta1.Select{Labels: extraLabels},
-			}},
+			Match:           nil,
 			Filters: []flowv1beta1.Filter{{
 				Grep: &filters.GrepConfig{
 					Regexp: []filters.RegexpSection{{
@@ -73,7 +71,7 @@ func (r *FlowTestReconciler) flowTemplates(flow flowv1beta1.Flow, flowTest loggi
 	return flowTemplate, outTemplate
 }
 
-func (r *FlowTestReconciler) clusterFlowTemplates(flow flowv1beta1.ClusterFlow, flowTest loggingplumberv1alpha1.FlowTest, extraLabels map[string]string) (flowv1beta1.ClusterFlow, flowv1beta1.ClusterOutput) {
+func (r *FlowTestReconciler) clusterFlowTemplates(flow flowv1beta1.ClusterFlow, flowTest loggingplumberv1alpha1.FlowTest) (flowv1beta1.ClusterFlow, flowv1beta1.ClusterOutput) {
 	flowTemplate := flowv1beta1.ClusterFlow{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "logging.banzaicloud.io/v1beta1",
@@ -86,9 +84,7 @@ func (r *FlowTestReconciler) clusterFlowTemplates(flow flowv1beta1.ClusterFlow, 
 		},
 		Spec: flowv1beta1.ClusterFlowSpec{
 			GlobalOutputRefs: nil,
-			Match: []flowv1beta1.ClusterMatch{{
-				//ClusterSelect: &flowv1beta1.ClusterSelect{Labels: extraLabels},
-			}},
+			Match:            nil,
 			Filters: []flowv1beta1.Filter{{
 				Grep: &filters.GrepConfig{
 					Regexp: []filters.RegexpSection{{

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -36,7 +36,7 @@ func (r *FlowTestReconciler) flowTemplates(flow flowv1beta1.Flow, flowTest loggi
 		Spec: flowv1beta1.FlowSpec{
 			LocalOutputRefs: nil,
 			Match: []flowv1beta1.Match{{
-				Select: &flowv1beta1.Select{Labels: extraLabels},
+				//Select: &flowv1beta1.Select{Labels: extraLabels},
 			}},
 			Filters: []flowv1beta1.Filter{{
 				Grep: &filters.GrepConfig{
@@ -87,7 +87,7 @@ func (r *FlowTestReconciler) clusterFlowTemplates(flow flowv1beta1.ClusterFlow, 
 		Spec: flowv1beta1.ClusterFlowSpec{
 			GlobalOutputRefs: nil,
 			Match: []flowv1beta1.ClusterMatch{{
-				ClusterSelect: &flowv1beta1.ClusterSelect{Labels: extraLabels},
+				//ClusterSelect: &flowv1beta1.ClusterSelect{Labels: extraLabels},
 			}},
 			Filters: []flowv1beta1.Filter{{
 				Grep: &filters.GrepConfig{


### PR DESCRIPTION
#66 happened because I added extra labels to the first match statement and it will always go true, I fixed that with this PR.

I also updated the match peeler to test match statements individually, so now the results would look exactly as we want for the samples given in Issue #66,

![image](https://user-images.githubusercontent.com/29277992/130070259-d3477e8d-8fc7-4cbc-9283-7262eeace862.png)

but I am not sure how it will act with the exclude statements. In banzai docs it says
> Match statements are evaluated in the order they are defined and processed only until the first matching select or exclude rule applies.

if we go with the previous approach (slicing till `N`) and it will look like this
![image](https://user-images.githubusercontent.com/29277992/130075593-ee54a322-1c92-44cb-be3e-87615da1a836.png)

this is because it only tests till the first valid one once that valid one is hit it will forward logs even though there are invalid labels.